### PR TITLE
add "main" definition to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "vitest": "^0.25.3"
   },
   "type": "module",
+  "main": "index.js",
   "keywords": [
     "svelte",
     "sveltekit",


### PR DESCRIPTION
## 📑 Description

I'm unable to build my svelte-kit project on vercel due to rollup throwing this: `Rollup failed to resolve import "svelte-heros-V2"`
I think this PR will fix that. In the svelte-heros-V1 this is set and rollup has no issues with it.