### PR TITLE
fix: default variation size

### DIFF
--- a/src/lib/AcademicCap.svelte
+++ b/src/lib/AcademicCap.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/AcademicCap.svelte
+++ b/src/lib/AcademicCap.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/AdjustmentsHorizontal.svelte
+++ b/src/lib/AdjustmentsHorizontal.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -166,7 +166,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/AdjustmentsHorizontal.svelte
+++ b/src/lib/AdjustmentsHorizontal.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/AdjustmentsVertical.svelte
+++ b/src/lib/AdjustmentsVertical.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -166,7 +166,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/AdjustmentsVertical.svelte
+++ b/src/lib/AdjustmentsVertical.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArchiveBox.svelte
+++ b/src/lib/ArchiveBox.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArchiveBox.svelte
+++ b/src/lib/ArchiveBox.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArchiveBoxArrowDown.svelte
+++ b/src/lib/ArchiveBoxArrowDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArchiveBoxArrowDown.svelte
+++ b/src/lib/ArchiveBoxArrowDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArchiveBoxXMark.svelte
+++ b/src/lib/ArchiveBoxXMark.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArchiveBoxXMark.svelte
+++ b/src/lib/ArchiveBoxXMark.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowDown.svelte
+++ b/src/lib/ArrowDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowDown.svelte
+++ b/src/lib/ArrowDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowDownCircle.svelte
+++ b/src/lib/ArrowDownCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowDownCircle.svelte
+++ b/src/lib/ArrowDownCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowDownLeft.svelte
+++ b/src/lib/ArrowDownLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowDownLeft.svelte
+++ b/src/lib/ArrowDownLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowDownOnSquare.svelte
+++ b/src/lib/ArrowDownOnSquare.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -90,7 +90,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowDownOnSquare.svelte
+++ b/src/lib/ArrowDownOnSquare.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowDownOnSquareStack.svelte
+++ b/src/lib/ArrowDownOnSquareStack.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowDownOnSquareStack.svelte
+++ b/src/lib/ArrowDownOnSquareStack.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -98,7 +98,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowDownRight.svelte
+++ b/src/lib/ArrowDownRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -86,7 +86,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowDownRight.svelte
+++ b/src/lib/ArrowDownRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowDownTray.svelte
+++ b/src/lib/ArrowDownTray.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowDownTray.svelte
+++ b/src/lib/ArrowDownTray.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowLeft.svelte
+++ b/src/lib/ArrowLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowLeft.svelte
+++ b/src/lib/ArrowLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowLeftCircle.svelte
+++ b/src/lib/ArrowLeftCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -93,7 +93,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowLeftCircle.svelte
+++ b/src/lib/ArrowLeftCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowLeftEndOnRectangle.svelte
+++ b/src/lib/ArrowLeftEndOnRectangle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowLeftEndOnRectangle.svelte
+++ b/src/lib/ArrowLeftEndOnRectangle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowLeftOnRectangle.svelte
+++ b/src/lib/ArrowLeftOnRectangle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -89,7 +89,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowLeftOnRectangle.svelte
+++ b/src/lib/ArrowLeftOnRectangle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowLeftStartOnRectangle.svelte
+++ b/src/lib/ArrowLeftStartOnRectangle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowLeftStartOnRectangle.svelte
+++ b/src/lib/ArrowLeftStartOnRectangle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowLongDown.svelte
+++ b/src/lib/ArrowLongDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowLongDown.svelte
+++ b/src/lib/ArrowLongDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowLongLeft.svelte
+++ b/src/lib/ArrowLongLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowLongLeft.svelte
+++ b/src/lib/ArrowLongLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowLongRight.svelte
+++ b/src/lib/ArrowLongRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowLongRight.svelte
+++ b/src/lib/ArrowLongRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowLongUp.svelte
+++ b/src/lib/ArrowLongUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowLongUp.svelte
+++ b/src/lib/ArrowLongUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowPath.svelte
+++ b/src/lib/ArrowPath.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowPath.svelte
+++ b/src/lib/ArrowPath.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowPathRoundedSquare.svelte
+++ b/src/lib/ArrowPathRoundedSquare.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowPathRoundedSquare.svelte
+++ b/src/lib/ArrowPathRoundedSquare.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowRight.svelte
+++ b/src/lib/ArrowRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowRight.svelte
+++ b/src/lib/ArrowRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowRightCircle.svelte
+++ b/src/lib/ArrowRightCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowRightCircle.svelte
+++ b/src/lib/ArrowRightCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowRightEndOnRectangle.svelte
+++ b/src/lib/ArrowRightEndOnRectangle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowRightEndOnRectangle.svelte
+++ b/src/lib/ArrowRightEndOnRectangle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowRightOnRectangle.svelte
+++ b/src/lib/ArrowRightOnRectangle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -89,7 +89,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowRightOnRectangle.svelte
+++ b/src/lib/ArrowRightOnRectangle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowRightStartOnRectangle.svelte
+++ b/src/lib/ArrowRightStartOnRectangle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowRightStartOnRectangle.svelte
+++ b/src/lib/ArrowRightStartOnRectangle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowSmallDown.svelte
+++ b/src/lib/ArrowSmallDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -83,7 +83,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowSmallDown.svelte
+++ b/src/lib/ArrowSmallDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowSmallLeft.svelte
+++ b/src/lib/ArrowSmallLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -83,7 +83,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowSmallLeft.svelte
+++ b/src/lib/ArrowSmallLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowSmallRight.svelte
+++ b/src/lib/ArrowSmallRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -83,7 +83,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowSmallRight.svelte
+++ b/src/lib/ArrowSmallRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowSmallUp.svelte
+++ b/src/lib/ArrowSmallUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -83,7 +83,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowSmallUp.svelte
+++ b/src/lib/ArrowSmallUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowTopRightOnSquare.svelte
+++ b/src/lib/ArrowTopRightOnSquare.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowTopRightOnSquare.svelte
+++ b/src/lib/ArrowTopRightOnSquare.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowTrendingDown.svelte
+++ b/src/lib/ArrowTrendingDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowTrendingDown.svelte
+++ b/src/lib/ArrowTrendingDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowTrendingUp.svelte
+++ b/src/lib/ArrowTrendingUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowTrendingUp.svelte
+++ b/src/lib/ArrowTrendingUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowTurnDownLeft.svelte
+++ b/src/lib/ArrowTurnDownLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowTurnDownLeft.svelte
+++ b/src/lib/ArrowTurnDownLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowTurnDownRight.svelte
+++ b/src/lib/ArrowTurnDownRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowTurnDownRight.svelte
+++ b/src/lib/ArrowTurnDownRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowTurnLeftDown.svelte
+++ b/src/lib/ArrowTurnLeftDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowTurnLeftDown.svelte
+++ b/src/lib/ArrowTurnLeftDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowTurnLeftUp.svelte
+++ b/src/lib/ArrowTurnLeftUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowTurnLeftUp.svelte
+++ b/src/lib/ArrowTurnLeftUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowTurnRightDown.svelte
+++ b/src/lib/ArrowTurnRightDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowTurnRightDown.svelte
+++ b/src/lib/ArrowTurnRightDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowTurnRightUp.svelte
+++ b/src/lib/ArrowTurnRightUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowTurnRightUp.svelte
+++ b/src/lib/ArrowTurnRightUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowTurnUpLeft.svelte
+++ b/src/lib/ArrowTurnUpLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowTurnUpLeft.svelte
+++ b/src/lib/ArrowTurnUpLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowTurnUpRight.svelte
+++ b/src/lib/ArrowTurnUpRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowTurnUpRight.svelte
+++ b/src/lib/ArrowTurnUpRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowUp.svelte
+++ b/src/lib/ArrowUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowUp.svelte
+++ b/src/lib/ArrowUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowUpCircle.svelte
+++ b/src/lib/ArrowUpCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowUpCircle.svelte
+++ b/src/lib/ArrowUpCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowUpLeft.svelte
+++ b/src/lib/ArrowUpLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowUpLeft.svelte
+++ b/src/lib/ArrowUpLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowUpOnSquare.svelte
+++ b/src/lib/ArrowUpOnSquare.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowUpOnSquare.svelte
+++ b/src/lib/ArrowUpOnSquare.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowUpOnSquareStack.svelte
+++ b/src/lib/ArrowUpOnSquareStack.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowUpOnSquareStack.svelte
+++ b/src/lib/ArrowUpOnSquareStack.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowUpRight.svelte
+++ b/src/lib/ArrowUpRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowUpRight.svelte
+++ b/src/lib/ArrowUpRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowUpTray.svelte
+++ b/src/lib/ArrowUpTray.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowUpTray.svelte
+++ b/src/lib/ArrowUpTray.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowUturnDown.svelte
+++ b/src/lib/ArrowUturnDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowUturnDown.svelte
+++ b/src/lib/ArrowUturnDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowUturnLeft.svelte
+++ b/src/lib/ArrowUturnLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowUturnLeft.svelte
+++ b/src/lib/ArrowUturnLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowUturnRight.svelte
+++ b/src/lib/ArrowUturnRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowUturnRight.svelte
+++ b/src/lib/ArrowUturnRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowUturnUp.svelte
+++ b/src/lib/ArrowUturnUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowUturnUp.svelte
+++ b/src/lib/ArrowUturnUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowsPointingIn.svelte
+++ b/src/lib/ArrowsPointingIn.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowsPointingIn.svelte
+++ b/src/lib/ArrowsPointingIn.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -98,7 +98,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowsPointingOut.svelte
+++ b/src/lib/ArrowsPointingOut.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -116,7 +116,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowsPointingOut.svelte
+++ b/src/lib/ArrowsPointingOut.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowsRightLeft.svelte
+++ b/src/lib/ArrowsRightLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ArrowsRightLeft.svelte
+++ b/src/lib/ArrowsRightLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowsUpDown.svelte
+++ b/src/lib/ArrowsUpDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ArrowsUpDown.svelte
+++ b/src/lib/ArrowsUpDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/AtSymbol.svelte
+++ b/src/lib/AtSymbol.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/AtSymbol.svelte
+++ b/src/lib/AtSymbol.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Backspace.svelte
+++ b/src/lib/Backspace.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Backspace.svelte
+++ b/src/lib/Backspace.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Backward.svelte
+++ b/src/lib/Backward.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -89,7 +89,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Backward.svelte
+++ b/src/lib/Backward.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Banknotes.svelte
+++ b/src/lib/Banknotes.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Banknotes.svelte
+++ b/src/lib/Banknotes.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Bars2.svelte
+++ b/src/lib/Bars2.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Bars2.svelte
+++ b/src/lib/Bars2.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Bars3.svelte
+++ b/src/lib/Bars3.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Bars3.svelte
+++ b/src/lib/Bars3.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Bars3BottomLeft.svelte
+++ b/src/lib/Bars3BottomLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Bars3BottomLeft.svelte
+++ b/src/lib/Bars3BottomLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Bars3BottomRight.svelte
+++ b/src/lib/Bars3BottomRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Bars3BottomRight.svelte
+++ b/src/lib/Bars3BottomRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Bars3CenterLeft.svelte
+++ b/src/lib/Bars3CenterLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Bars3CenterLeft.svelte
+++ b/src/lib/Bars3CenterLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Bars4.svelte
+++ b/src/lib/Bars4.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Bars4.svelte
+++ b/src/lib/Bars4.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BarsArrowDown.svelte
+++ b/src/lib/BarsArrowDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BarsArrowDown.svelte
+++ b/src/lib/BarsArrowDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BarsArrowUp.svelte
+++ b/src/lib/BarsArrowUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BarsArrowUp.svelte
+++ b/src/lib/BarsArrowUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Battery0.svelte
+++ b/src/lib/Battery0.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Battery0.svelte
+++ b/src/lib/Battery0.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Battery100.svelte
+++ b/src/lib/Battery100.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Battery100.svelte
+++ b/src/lib/Battery100.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Battery50.svelte
+++ b/src/lib/Battery50.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Battery50.svelte
+++ b/src/lib/Battery50.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Beaker.svelte
+++ b/src/lib/Beaker.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Beaker.svelte
+++ b/src/lib/Beaker.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Bell.svelte
+++ b/src/lib/Bell.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Bell.svelte
+++ b/src/lib/Bell.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BellAlert.svelte
+++ b/src/lib/BellAlert.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BellAlert.svelte
+++ b/src/lib/BellAlert.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -112,7 +112,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BellSlash.svelte
+++ b/src/lib/BellSlash.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -110,7 +110,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BellSlash.svelte
+++ b/src/lib/BellSlash.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BellSnooze.svelte
+++ b/src/lib/BellSnooze.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BellSnooze.svelte
+++ b/src/lib/BellSnooze.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Bold.svelte
+++ b/src/lib/Bold.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -87,7 +87,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Bold.svelte
+++ b/src/lib/Bold.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Bolt.svelte
+++ b/src/lib/Bolt.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -86,7 +86,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Bolt.svelte
+++ b/src/lib/Bolt.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BoltSlash.svelte
+++ b/src/lib/BoltSlash.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -116,7 +116,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BoltSlash.svelte
+++ b/src/lib/BoltSlash.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BookOpen.svelte
+++ b/src/lib/BookOpen.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BookOpen.svelte
+++ b/src/lib/BookOpen.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Bookmark.svelte
+++ b/src/lib/Bookmark.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -86,7 +86,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Bookmark.svelte
+++ b/src/lib/Bookmark.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BookmarkSlash.svelte
+++ b/src/lib/BookmarkSlash.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BookmarkSlash.svelte
+++ b/src/lib/BookmarkSlash.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -103,7 +103,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BookmarkSquare.svelte
+++ b/src/lib/BookmarkSquare.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BookmarkSquare.svelte
+++ b/src/lib/BookmarkSquare.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Briefcase.svelte
+++ b/src/lib/Briefcase.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Briefcase.svelte
+++ b/src/lib/Briefcase.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BugAnt.svelte
+++ b/src/lib/BugAnt.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -86,7 +86,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BugAnt.svelte
+++ b/src/lib/BugAnt.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BuildingLibrary.svelte
+++ b/src/lib/BuildingLibrary.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BuildingLibrary.svelte
+++ b/src/lib/BuildingLibrary.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BuildingOffice.svelte
+++ b/src/lib/BuildingOffice.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BuildingOffice.svelte
+++ b/src/lib/BuildingOffice.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BuildingOffice2.svelte
+++ b/src/lib/BuildingOffice2.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BuildingOffice2.svelte
+++ b/src/lib/BuildingOffice2.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/BuildingStorefront.svelte
+++ b/src/lib/BuildingStorefront.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/BuildingStorefront.svelte
+++ b/src/lib/BuildingStorefront.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Cake.svelte
+++ b/src/lib/Cake.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -138,7 +138,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Cake.svelte
+++ b/src/lib/Cake.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Calculator.svelte
+++ b/src/lib/Calculator.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Calculator.svelte
+++ b/src/lib/Calculator.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Calendar.svelte
+++ b/src/lib/Calendar.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Calendar.svelte
+++ b/src/lib/Calendar.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CalendarDateRange.svelte
+++ b/src/lib/CalendarDateRange.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -172,7 +172,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CalendarDateRange.svelte
+++ b/src/lib/CalendarDateRange.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CalendarDays.svelte
+++ b/src/lib/CalendarDays.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -204,7 +204,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CalendarDays.svelte
+++ b/src/lib/CalendarDays.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Camera.svelte
+++ b/src/lib/Camera.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -110,7 +110,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Camera.svelte
+++ b/src/lib/Camera.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChartBar.svelte
+++ b/src/lib/ChartBar.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -120,7 +120,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChartBar.svelte
+++ b/src/lib/ChartBar.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChartBarSquare.svelte
+++ b/src/lib/ChartBarSquare.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChartBarSquare.svelte
+++ b/src/lib/ChartBarSquare.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChartPie.svelte
+++ b/src/lib/ChartPie.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -105,7 +105,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChartPie.svelte
+++ b/src/lib/ChartPie.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChatBubbleBottomCenter.svelte
+++ b/src/lib/ChatBubbleBottomCenter.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -86,7 +86,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChatBubbleBottomCenter.svelte
+++ b/src/lib/ChatBubbleBottomCenter.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChatBubbleBottomCenterText.svelte
+++ b/src/lib/ChatBubbleBottomCenterText.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChatBubbleBottomCenterText.svelte
+++ b/src/lib/ChatBubbleBottomCenterText.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChatBubbleLeft.svelte
+++ b/src/lib/ChatBubbleLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -86,7 +86,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChatBubbleLeft.svelte
+++ b/src/lib/ChatBubbleLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChatBubbleLeftEllipsis.svelte
+++ b/src/lib/ChatBubbleLeftEllipsis.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChatBubbleLeftEllipsis.svelte
+++ b/src/lib/ChatBubbleLeftEllipsis.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChatBubbleLeftRight.svelte
+++ b/src/lib/ChatBubbleLeftRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChatBubbleLeftRight.svelte
+++ b/src/lib/ChatBubbleLeftRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChatBubbleOvalLeft.svelte
+++ b/src/lib/ChatBubbleOvalLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChatBubbleOvalLeft.svelte
+++ b/src/lib/ChatBubbleOvalLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChatBubbleOvalLeftEllipsis.svelte
+++ b/src/lib/ChatBubbleOvalLeftEllipsis.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChatBubbleOvalLeftEllipsis.svelte
+++ b/src/lib/ChatBubbleOvalLeftEllipsis.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Check.svelte
+++ b/src/lib/Check.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Check.svelte
+++ b/src/lib/Check.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CheckBadge.svelte
+++ b/src/lib/CheckBadge.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CheckBadge.svelte
+++ b/src/lib/CheckBadge.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CheckCircle.svelte
+++ b/src/lib/CheckCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CheckCircle.svelte
+++ b/src/lib/CheckCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChevronDoubleDown.svelte
+++ b/src/lib/ChevronDoubleDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChevronDoubleDown.svelte
+++ b/src/lib/ChevronDoubleDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChevronDoubleLeft.svelte
+++ b/src/lib/ChevronDoubleLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChevronDoubleLeft.svelte
+++ b/src/lib/ChevronDoubleLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChevronDoubleRight.svelte
+++ b/src/lib/ChevronDoubleRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChevronDoubleRight.svelte
+++ b/src/lib/ChevronDoubleRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChevronDoubleUp.svelte
+++ b/src/lib/ChevronDoubleUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChevronDoubleUp.svelte
+++ b/src/lib/ChevronDoubleUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -101,7 +101,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChevronDown.svelte
+++ b/src/lib/ChevronDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChevronDown.svelte
+++ b/src/lib/ChevronDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChevronLeft.svelte
+++ b/src/lib/ChevronLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChevronLeft.svelte
+++ b/src/lib/ChevronLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChevronRight.svelte
+++ b/src/lib/ChevronRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChevronRight.svelte
+++ b/src/lib/ChevronRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChevronUp.svelte
+++ b/src/lib/ChevronUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ChevronUp.svelte
+++ b/src/lib/ChevronUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChevronUpDown.svelte
+++ b/src/lib/ChevronUpDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ChevronUpDown.svelte
+++ b/src/lib/ChevronUpDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CircleStack.svelte
+++ b/src/lib/CircleStack.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -104,7 +104,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CircleStack.svelte
+++ b/src/lib/CircleStack.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Clipboard.svelte
+++ b/src/lib/Clipboard.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Clipboard.svelte
+++ b/src/lib/Clipboard.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ClipboardDocument.svelte
+++ b/src/lib/ClipboardDocument.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -104,7 +104,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ClipboardDocument.svelte
+++ b/src/lib/ClipboardDocument.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ClipboardDocumentCheck.svelte
+++ b/src/lib/ClipboardDocumentCheck.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ClipboardDocumentCheck.svelte
+++ b/src/lib/ClipboardDocumentCheck.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ClipboardDocumentList.svelte
+++ b/src/lib/ClipboardDocumentList.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ClipboardDocumentList.svelte
+++ b/src/lib/ClipboardDocumentList.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Clock.svelte
+++ b/src/lib/Clock.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Clock.svelte
+++ b/src/lib/Clock.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Cloud.svelte
+++ b/src/lib/Cloud.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Cloud.svelte
+++ b/src/lib/Cloud.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -84,7 +84,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CloudArrowDown.svelte
+++ b/src/lib/CloudArrowDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CloudArrowDown.svelte
+++ b/src/lib/CloudArrowDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CloudArrowUp.svelte
+++ b/src/lib/CloudArrowUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CloudArrowUp.svelte
+++ b/src/lib/CloudArrowUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CodeBracket.svelte
+++ b/src/lib/CodeBracket.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CodeBracket.svelte
+++ b/src/lib/CodeBracket.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CodeBracketSquare.svelte
+++ b/src/lib/CodeBracketSquare.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CodeBracketSquare.svelte
+++ b/src/lib/CodeBracketSquare.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Cog.svelte
+++ b/src/lib/Cog.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Cog.svelte
+++ b/src/lib/Cog.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -112,7 +112,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Cog6Tooth.svelte
+++ b/src/lib/Cog6Tooth.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Cog6Tooth.svelte
+++ b/src/lib/Cog6Tooth.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -95,7 +95,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Cog8Tooth.svelte
+++ b/src/lib/Cog8Tooth.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Cog8Tooth.svelte
+++ b/src/lib/Cog8Tooth.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -95,7 +95,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CommandLine.svelte
+++ b/src/lib/CommandLine.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CommandLine.svelte
+++ b/src/lib/CommandLine.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ComputerDesktop.svelte
+++ b/src/lib/ComputerDesktop.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ComputerDesktop.svelte
+++ b/src/lib/ComputerDesktop.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CpuChip.svelte
+++ b/src/lib/CpuChip.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -91,7 +91,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CpuChip.svelte
+++ b/src/lib/CpuChip.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CreditCard.svelte
+++ b/src/lib/CreditCard.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CreditCard.svelte
+++ b/src/lib/CreditCard.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Cube.svelte
+++ b/src/lib/Cube.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Cube.svelte
+++ b/src/lib/Cube.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CubeTransparent.svelte
+++ b/src/lib/CubeTransparent.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CubeTransparent.svelte
+++ b/src/lib/CubeTransparent.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CurrencyBangladeshi.svelte
+++ b/src/lib/CurrencyBangladeshi.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CurrencyBangladeshi.svelte
+++ b/src/lib/CurrencyBangladeshi.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CurrencyDollar.svelte
+++ b/src/lib/CurrencyDollar.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CurrencyDollar.svelte
+++ b/src/lib/CurrencyDollar.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -112,7 +112,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CurrencyEuro.svelte
+++ b/src/lib/CurrencyEuro.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CurrencyEuro.svelte
+++ b/src/lib/CurrencyEuro.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CurrencyPound.svelte
+++ b/src/lib/CurrencyPound.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CurrencyPound.svelte
+++ b/src/lib/CurrencyPound.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CurrencyRupee.svelte
+++ b/src/lib/CurrencyRupee.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CurrencyRupee.svelte
+++ b/src/lib/CurrencyRupee.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CurrencyYen.svelte
+++ b/src/lib/CurrencyYen.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CurrencyYen.svelte
+++ b/src/lib/CurrencyYen.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CursorArrowRays.svelte
+++ b/src/lib/CursorArrowRays.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -132,7 +132,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CursorArrowRays.svelte
+++ b/src/lib/CursorArrowRays.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/CursorArrowRipple.svelte
+++ b/src/lib/CursorArrowRipple.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/CursorArrowRipple.svelte
+++ b/src/lib/CursorArrowRipple.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DevicePhoneMobile.svelte
+++ b/src/lib/DevicePhoneMobile.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DevicePhoneMobile.svelte
+++ b/src/lib/DevicePhoneMobile.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DeviceTablet.svelte
+++ b/src/lib/DeviceTablet.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DeviceTablet.svelte
+++ b/src/lib/DeviceTablet.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Divide.svelte
+++ b/src/lib/Divide.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -102,7 +102,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Divide.svelte
+++ b/src/lib/Divide.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Document.svelte
+++ b/src/lib/Document.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -86,7 +86,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Document.svelte
+++ b/src/lib/Document.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentArrowDown.svelte
+++ b/src/lib/DocumentArrowDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentArrowDown.svelte
+++ b/src/lib/DocumentArrowDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentArrowUp.svelte
+++ b/src/lib/DocumentArrowUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentArrowUp.svelte
+++ b/src/lib/DocumentArrowUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentChartBar.svelte
+++ b/src/lib/DocumentChartBar.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentChartBar.svelte
+++ b/src/lib/DocumentChartBar.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentCheck.svelte
+++ b/src/lib/DocumentCheck.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentCheck.svelte
+++ b/src/lib/DocumentCheck.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentCurrencyBangladeshi.svelte
+++ b/src/lib/DocumentCurrencyBangladeshi.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentCurrencyBangladeshi.svelte
+++ b/src/lib/DocumentCurrencyBangladeshi.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentCurrencyDollar.svelte
+++ b/src/lib/DocumentCurrencyDollar.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentCurrencyDollar.svelte
+++ b/src/lib/DocumentCurrencyDollar.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentCurrencyEuro.svelte
+++ b/src/lib/DocumentCurrencyEuro.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentCurrencyEuro.svelte
+++ b/src/lib/DocumentCurrencyEuro.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentCurrencyPound.svelte
+++ b/src/lib/DocumentCurrencyPound.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentCurrencyPound.svelte
+++ b/src/lib/DocumentCurrencyPound.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentCurrencyRupee.svelte
+++ b/src/lib/DocumentCurrencyRupee.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentCurrencyRupee.svelte
+++ b/src/lib/DocumentCurrencyRupee.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentCurrencyYen.svelte
+++ b/src/lib/DocumentCurrencyYen.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentCurrencyYen.svelte
+++ b/src/lib/DocumentCurrencyYen.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentDuplicate.svelte
+++ b/src/lib/DocumentDuplicate.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentDuplicate.svelte
+++ b/src/lib/DocumentDuplicate.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -98,7 +98,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentMagnifyingGlass.svelte
+++ b/src/lib/DocumentMagnifyingGlass.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -104,7 +104,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentMagnifyingGlass.svelte
+++ b/src/lib/DocumentMagnifyingGlass.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentMinus.svelte
+++ b/src/lib/DocumentMinus.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentMinus.svelte
+++ b/src/lib/DocumentMinus.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentPlus.svelte
+++ b/src/lib/DocumentPlus.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentPlus.svelte
+++ b/src/lib/DocumentPlus.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/DocumentText.svelte
+++ b/src/lib/DocumentText.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/DocumentText.svelte
+++ b/src/lib/DocumentText.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/EllipsisHorizontal.svelte
+++ b/src/lib/EllipsisHorizontal.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -114,7 +114,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/EllipsisHorizontal.svelte
+++ b/src/lib/EllipsisHorizontal.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/EllipsisHorizontalCircle.svelte
+++ b/src/lib/EllipsisHorizontalCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/EllipsisHorizontalCircle.svelte
+++ b/src/lib/EllipsisHorizontalCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/EllipsisVertical.svelte
+++ b/src/lib/EllipsisVertical.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -114,7 +114,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/EllipsisVertical.svelte
+++ b/src/lib/EllipsisVertical.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Envelope.svelte
+++ b/src/lib/Envelope.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Envelope.svelte
+++ b/src/lib/Envelope.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/EnvelopeOpen.svelte
+++ b/src/lib/EnvelopeOpen.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -90,7 +90,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/EnvelopeOpen.svelte
+++ b/src/lib/EnvelopeOpen.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Equals.svelte
+++ b/src/lib/Equals.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -102,7 +102,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Equals.svelte
+++ b/src/lib/Equals.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ExclamationCircle.svelte
+++ b/src/lib/ExclamationCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ExclamationCircle.svelte
+++ b/src/lib/ExclamationCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ExclamationTriangle.svelte
+++ b/src/lib/ExclamationTriangle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ExclamationTriangle.svelte
+++ b/src/lib/ExclamationTriangle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Eye.svelte
+++ b/src/lib/Eye.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -107,7 +107,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Eye.svelte
+++ b/src/lib/Eye.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/EyeDropper.svelte
+++ b/src/lib/EyeDropper.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/EyeDropper.svelte
+++ b/src/lib/EyeDropper.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/EyeSlash.svelte
+++ b/src/lib/EyeSlash.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -110,7 +110,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/EyeSlash.svelte
+++ b/src/lib/EyeSlash.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/FaceFrown.svelte
+++ b/src/lib/FaceFrown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/FaceFrown.svelte
+++ b/src/lib/FaceFrown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/FaceSmile.svelte
+++ b/src/lib/FaceSmile.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/FaceSmile.svelte
+++ b/src/lib/FaceSmile.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Film.svelte
+++ b/src/lib/Film.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Film.svelte
+++ b/src/lib/Film.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/FingerPrint.svelte
+++ b/src/lib/FingerPrint.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/FingerPrint.svelte
+++ b/src/lib/FingerPrint.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Fire.svelte
+++ b/src/lib/Fire.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Fire.svelte
+++ b/src/lib/Fire.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -95,7 +95,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Flag.svelte
+++ b/src/lib/Flag.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Flag.svelte
+++ b/src/lib/Flag.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -84,7 +84,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Folder.svelte
+++ b/src/lib/Folder.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Folder.svelte
+++ b/src/lib/Folder.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/FolderArrowDown.svelte
+++ b/src/lib/FolderArrowDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/FolderArrowDown.svelte
+++ b/src/lib/FolderArrowDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/FolderMinus.svelte
+++ b/src/lib/FolderMinus.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/FolderMinus.svelte
+++ b/src/lib/FolderMinus.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/FolderOpen.svelte
+++ b/src/lib/FolderOpen.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/FolderOpen.svelte
+++ b/src/lib/FolderOpen.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/FolderPlus.svelte
+++ b/src/lib/FolderPlus.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/FolderPlus.svelte
+++ b/src/lib/FolderPlus.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Forward.svelte
+++ b/src/lib/Forward.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -89,7 +89,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Forward.svelte
+++ b/src/lib/Forward.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Funnel.svelte
+++ b/src/lib/Funnel.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -86,7 +86,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Funnel.svelte
+++ b/src/lib/Funnel.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Gif.svelte
+++ b/src/lib/Gif.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Gif.svelte
+++ b/src/lib/Gif.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Gift.svelte
+++ b/src/lib/Gift.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Gift.svelte
+++ b/src/lib/Gift.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/GiftTop.svelte
+++ b/src/lib/GiftTop.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -124,7 +124,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/GiftTop.svelte
+++ b/src/lib/GiftTop.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/GlobeAlt.svelte
+++ b/src/lib/GlobeAlt.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -148,7 +148,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/GlobeAlt.svelte
+++ b/src/lib/GlobeAlt.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/GlobeAmericas.svelte
+++ b/src/lib/GlobeAmericas.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/GlobeAmericas.svelte
+++ b/src/lib/GlobeAmericas.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/GlobeAsiaAustralia.svelte
+++ b/src/lib/GlobeAsiaAustralia.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/GlobeAsiaAustralia.svelte
+++ b/src/lib/GlobeAsiaAustralia.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/GlobeEuropeAfrica.svelte
+++ b/src/lib/GlobeEuropeAfrica.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/GlobeEuropeAfrica.svelte
+++ b/src/lib/GlobeEuropeAfrica.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/H1.svelte
+++ b/src/lib/H1.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/H1.svelte
+++ b/src/lib/H1.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/H2.svelte
+++ b/src/lib/H2.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/H2.svelte
+++ b/src/lib/H2.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/H3.svelte
+++ b/src/lib/H3.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/H3.svelte
+++ b/src/lib/H3.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/HandRaised.svelte
+++ b/src/lib/HandRaised.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/HandRaised.svelte
+++ b/src/lib/HandRaised.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -84,7 +84,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/HandThumbDown.svelte
+++ b/src/lib/HandThumbDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/HandThumbDown.svelte
+++ b/src/lib/HandThumbDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/HandThumbUp.svelte
+++ b/src/lib/HandThumbUp.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/HandThumbUp.svelte
+++ b/src/lib/HandThumbUp.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Hashtag.svelte
+++ b/src/lib/Hashtag.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Hashtag.svelte
+++ b/src/lib/Hashtag.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Heart.svelte
+++ b/src/lib/Heart.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -82,7 +82,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Heart.svelte
+++ b/src/lib/Heart.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Home.svelte
+++ b/src/lib/Home.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/HomeModern.svelte
+++ b/src/lib/HomeModern.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/HomeModern.svelte
+++ b/src/lib/HomeModern.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Identification.svelte
+++ b/src/lib/Identification.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Identification.svelte
+++ b/src/lib/Identification.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Inbox.svelte
+++ b/src/lib/Inbox.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Inbox.svelte
+++ b/src/lib/Inbox.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/InboxArrowDown.svelte
+++ b/src/lib/InboxArrowDown.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/InboxArrowDown.svelte
+++ b/src/lib/InboxArrowDown.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -98,7 +98,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/InboxStack.svelte
+++ b/src/lib/InboxStack.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/InboxStack.svelte
+++ b/src/lib/InboxStack.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/InformationCircle.svelte
+++ b/src/lib/InformationCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/InformationCircle.svelte
+++ b/src/lib/InformationCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Italic.svelte
+++ b/src/lib/Italic.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Italic.svelte
+++ b/src/lib/Italic.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Key.svelte
+++ b/src/lib/Key.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Key.svelte
+++ b/src/lib/Key.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Language.svelte
+++ b/src/lib/Language.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Language.svelte
+++ b/src/lib/Language.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -98,7 +98,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Lifebuoy.svelte
+++ b/src/lib/Lifebuoy.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Lifebuoy.svelte
+++ b/src/lib/Lifebuoy.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/LightBulb.svelte
+++ b/src/lib/LightBulb.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -102,7 +102,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/LightBulb.svelte
+++ b/src/lib/LightBulb.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Link.svelte
+++ b/src/lib/Link.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Link.svelte
+++ b/src/lib/Link.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/LinkSlash.svelte
+++ b/src/lib/LinkSlash.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -90,7 +90,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/LinkSlash.svelte
+++ b/src/lib/LinkSlash.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ListBullet.svelte
+++ b/src/lib/ListBullet.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -124,7 +124,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ListBullet.svelte
+++ b/src/lib/ListBullet.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/LockClosed.svelte
+++ b/src/lib/LockClosed.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/LockClosed.svelte
+++ b/src/lib/LockClosed.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/LockOpen.svelte
+++ b/src/lib/LockOpen.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/LockOpen.svelte
+++ b/src/lib/LockOpen.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -84,7 +84,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/MagnifyingGlass.svelte
+++ b/src/lib/MagnifyingGlass.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/MagnifyingGlass.svelte
+++ b/src/lib/MagnifyingGlass.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/MagnifyingGlassCircle.svelte
+++ b/src/lib/MagnifyingGlassCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/MagnifyingGlassCircle.svelte
+++ b/src/lib/MagnifyingGlassCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/MagnifyingGlassMinus.svelte
+++ b/src/lib/MagnifyingGlassMinus.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/MagnifyingGlassMinus.svelte
+++ b/src/lib/MagnifyingGlassMinus.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/MagnifyingGlassPlus.svelte
+++ b/src/lib/MagnifyingGlassPlus.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/MagnifyingGlassPlus.svelte
+++ b/src/lib/MagnifyingGlassPlus.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Map.svelte
+++ b/src/lib/Map.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Map.svelte
+++ b/src/lib/Map.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/MapPin.svelte
+++ b/src/lib/MapPin.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/MapPin.svelte
+++ b/src/lib/MapPin.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -95,7 +95,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Megaphone.svelte
+++ b/src/lib/Megaphone.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Megaphone.svelte
+++ b/src/lib/Megaphone.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Microphone.svelte
+++ b/src/lib/Microphone.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Microphone.svelte
+++ b/src/lib/Microphone.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Minus.svelte
+++ b/src/lib/Minus.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -86,7 +86,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Minus.svelte
+++ b/src/lib/Minus.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/MinusCircle.svelte
+++ b/src/lib/MinusCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/MinusCircle.svelte
+++ b/src/lib/MinusCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/MinusSmall.svelte
+++ b/src/lib/MinusSmall.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -81,7 +81,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/MinusSmall.svelte
+++ b/src/lib/MinusSmall.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Moon.svelte
+++ b/src/lib/Moon.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -86,7 +86,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Moon.svelte
+++ b/src/lib/Moon.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/MusicalNote.svelte
+++ b/src/lib/MusicalNote.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -86,7 +86,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/MusicalNote.svelte
+++ b/src/lib/MusicalNote.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Newspaper.svelte
+++ b/src/lib/Newspaper.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Newspaper.svelte
+++ b/src/lib/Newspaper.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/NoSymbol.svelte
+++ b/src/lib/NoSymbol.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/NoSymbol.svelte
+++ b/src/lib/NoSymbol.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/NumberedList.svelte
+++ b/src/lib/NumberedList.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -154,7 +154,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/NumberedList.svelte
+++ b/src/lib/NumberedList.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PaintBrush.svelte
+++ b/src/lib/PaintBrush.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PaintBrush.svelte
+++ b/src/lib/PaintBrush.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PaperAirplane.svelte
+++ b/src/lib/PaperAirplane.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -82,7 +82,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PaperAirplane.svelte
+++ b/src/lib/PaperAirplane.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PaperClip.svelte
+++ b/src/lib/PaperClip.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PaperClip.svelte
+++ b/src/lib/PaperClip.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Pause.svelte
+++ b/src/lib/Pause.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -92,7 +92,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Pause.svelte
+++ b/src/lib/Pause.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PauseCircle.svelte
+++ b/src/lib/PauseCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PauseCircle.svelte
+++ b/src/lib/PauseCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Pencil.svelte
+++ b/src/lib/Pencil.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Pencil.svelte
+++ b/src/lib/Pencil.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PencilSquare.svelte
+++ b/src/lib/PencilSquare.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PencilSquare.svelte
+++ b/src/lib/PencilSquare.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -98,7 +98,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PercentBadge.svelte
+++ b/src/lib/PercentBadge.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PercentBadge.svelte
+++ b/src/lib/PercentBadge.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Phone.svelte
+++ b/src/lib/Phone.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Phone.svelte
+++ b/src/lib/Phone.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PhoneArrowDownLeft.svelte
+++ b/src/lib/PhoneArrowDownLeft.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PhoneArrowDownLeft.svelte
+++ b/src/lib/PhoneArrowDownLeft.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -98,7 +98,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PhoneArrowUpRight.svelte
+++ b/src/lib/PhoneArrowUpRight.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PhoneArrowUpRight.svelte
+++ b/src/lib/PhoneArrowUpRight.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -98,7 +98,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PhoneXMark.svelte
+++ b/src/lib/PhoneXMark.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PhoneXMark.svelte
+++ b/src/lib/PhoneXMark.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Photo.svelte
+++ b/src/lib/Photo.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Photo.svelte
+++ b/src/lib/Photo.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Play.svelte
+++ b/src/lib/Play.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Play.svelte
+++ b/src/lib/Play.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -84,7 +84,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PlayCircle.svelte
+++ b/src/lib/PlayCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PlayCircle.svelte
+++ b/src/lib/PlayCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -95,7 +95,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PlayPause.svelte
+++ b/src/lib/PlayPause.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PlayPause.svelte
+++ b/src/lib/PlayPause.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Plus.svelte
+++ b/src/lib/Plus.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Plus.svelte
+++ b/src/lib/Plus.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -84,7 +84,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PlusCircle.svelte
+++ b/src/lib/PlusCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PlusCircle.svelte
+++ b/src/lib/PlusCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PlusSmall.svelte
+++ b/src/lib/PlusSmall.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -81,7 +81,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PlusSmall.svelte
+++ b/src/lib/PlusSmall.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Power.svelte
+++ b/src/lib/Power.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Power.svelte
+++ b/src/lib/Power.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PresentationChartBar.svelte
+++ b/src/lib/PresentationChartBar.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PresentationChartBar.svelte
+++ b/src/lib/PresentationChartBar.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PresentationChartLine.svelte
+++ b/src/lib/PresentationChartLine.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/PresentationChartLine.svelte
+++ b/src/lib/PresentationChartLine.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Printer.svelte
+++ b/src/lib/Printer.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Printer.svelte
+++ b/src/lib/Printer.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PuzzlePiece.svelte
+++ b/src/lib/PuzzlePiece.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -82,7 +82,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/PuzzlePiece.svelte
+++ b/src/lib/PuzzlePiece.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/QrCode.svelte
+++ b/src/lib/QrCode.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -202,7 +202,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/QrCode.svelte
+++ b/src/lib/QrCode.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/QuestionMarkCircle.svelte
+++ b/src/lib/QuestionMarkCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/QuestionMarkCircle.svelte
+++ b/src/lib/QuestionMarkCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/QueueList.svelte
+++ b/src/lib/QueueList.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -114,7 +114,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/QueueList.svelte
+++ b/src/lib/QueueList.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Radio.svelte
+++ b/src/lib/Radio.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Radio.svelte
+++ b/src/lib/Radio.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ReceiptPercent.svelte
+++ b/src/lib/ReceiptPercent.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ReceiptPercent.svelte
+++ b/src/lib/ReceiptPercent.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ReceiptRefund.svelte
+++ b/src/lib/ReceiptRefund.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ReceiptRefund.svelte
+++ b/src/lib/ReceiptRefund.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/RectangleGroup.svelte
+++ b/src/lib/RectangleGroup.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -108,7 +108,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/RectangleGroup.svelte
+++ b/src/lib/RectangleGroup.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/RectangleStack.svelte
+++ b/src/lib/RectangleStack.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/RectangleStack.svelte
+++ b/src/lib/RectangleStack.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -103,7 +103,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/RocketLaunch.svelte
+++ b/src/lib/RocketLaunch.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -102,7 +102,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/RocketLaunch.svelte
+++ b/src/lib/RocketLaunch.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Rss.svelte
+++ b/src/lib/Rss.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Rss.svelte
+++ b/src/lib/Rss.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Scale.svelte
+++ b/src/lib/Scale.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Scale.svelte
+++ b/src/lib/Scale.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Scissors.svelte
+++ b/src/lib/Scissors.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -118,7 +118,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Scissors.svelte
+++ b/src/lib/Scissors.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Server.svelte
+++ b/src/lib/Server.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -100,7 +100,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Server.svelte
+++ b/src/lib/Server.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ServerStack.svelte
+++ b/src/lib/ServerStack.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -118,7 +118,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ServerStack.svelte
+++ b/src/lib/ServerStack.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Share.svelte
+++ b/src/lib/Share.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Share.svelte
+++ b/src/lib/Share.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -84,7 +84,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ShieldCheck.svelte
+++ b/src/lib/ShieldCheck.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ShieldCheck.svelte
+++ b/src/lib/ShieldCheck.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ShieldExclamation.svelte
+++ b/src/lib/ShieldExclamation.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ShieldExclamation.svelte
+++ b/src/lib/ShieldExclamation.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ShoppingBag.svelte
+++ b/src/lib/ShoppingBag.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ShoppingBag.svelte
+++ b/src/lib/ShoppingBag.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ShoppingCart.svelte
+++ b/src/lib/ShoppingCart.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ShoppingCart.svelte
+++ b/src/lib/ShoppingCart.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Signal.svelte
+++ b/src/lib/Signal.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Signal.svelte
+++ b/src/lib/Signal.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -112,7 +112,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/SignalSlash.svelte
+++ b/src/lib/SignalSlash.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -116,7 +116,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/SignalSlash.svelte
+++ b/src/lib/SignalSlash.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Slash.svelte
+++ b/src/lib/Slash.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Slash.svelte
+++ b/src/lib/Slash.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Sparkles.svelte
+++ b/src/lib/Sparkles.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -132,7 +132,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Sparkles.svelte
+++ b/src/lib/Sparkles.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/SpeakerWave.svelte
+++ b/src/lib/SpeakerWave.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/SpeakerWave.svelte
+++ b/src/lib/SpeakerWave.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/SpeakerXMark.svelte
+++ b/src/lib/SpeakerXMark.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/SpeakerXMark.svelte
+++ b/src/lib/SpeakerXMark.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Square2Stack.svelte
+++ b/src/lib/Square2Stack.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Square2Stack.svelte
+++ b/src/lib/Square2Stack.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Square3Stack3d.svelte
+++ b/src/lib/Square3Stack3d.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Square3Stack3d.svelte
+++ b/src/lib/Square3Stack3d.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Squares2x2.svelte
+++ b/src/lib/Squares2x2.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -119,7 +119,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Squares2x2.svelte
+++ b/src/lib/Squares2x2.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/SquaresPlus.svelte
+++ b/src/lib/SquaresPlus.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -118,7 +118,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/SquaresPlus.svelte
+++ b/src/lib/SquaresPlus.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Star.svelte
+++ b/src/lib/Star.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Star.svelte
+++ b/src/lib/Star.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Stop.svelte
+++ b/src/lib/Stop.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -81,7 +81,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Stop.svelte
+++ b/src/lib/Stop.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/StopCircle.svelte
+++ b/src/lib/StopCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/StopCircle.svelte
+++ b/src/lib/StopCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -95,7 +95,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Strikethrough.svelte
+++ b/src/lib/Strikethrough.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Strikethrough.svelte
+++ b/src/lib/Strikethrough.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Sun.svelte
+++ b/src/lib/Sun.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -178,7 +178,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Sun.svelte
+++ b/src/lib/Sun.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Swatch.svelte
+++ b/src/lib/Swatch.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -104,7 +104,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Swatch.svelte
+++ b/src/lib/Swatch.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/TableCells.svelte
+++ b/src/lib/TableCells.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/TableCells.svelte
+++ b/src/lib/TableCells.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Tag.svelte
+++ b/src/lib/Tag.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Tag.svelte
+++ b/src/lib/Tag.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -95,7 +95,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Ticket.svelte
+++ b/src/lib/Ticket.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Ticket.svelte
+++ b/src/lib/Ticket.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Trash.svelte
+++ b/src/lib/Trash.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Trash.svelte
+++ b/src/lib/Trash.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Trophy.svelte
+++ b/src/lib/Trophy.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Trophy.svelte
+++ b/src/lib/Trophy.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Truck.svelte
+++ b/src/lib/Truck.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -130,7 +130,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Truck.svelte
+++ b/src/lib/Truck.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Tv.svelte
+++ b/src/lib/Tv.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -91,7 +91,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Tv.svelte
+++ b/src/lib/Tv.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Underline.svelte
+++ b/src/lib/Underline.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Underline.svelte
+++ b/src/lib/Underline.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/User.svelte
+++ b/src/lib/User.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -105,7 +105,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/User.svelte
+++ b/src/lib/User.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/UserCircle.svelte
+++ b/src/lib/UserCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/UserCircle.svelte
+++ b/src/lib/UserCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/UserGroup.svelte
+++ b/src/lib/UserGroup.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -150,7 +150,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/UserGroup.svelte
+++ b/src/lib/UserGroup.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/UserMinus.svelte
+++ b/src/lib/UserMinus.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/UserMinus.svelte
+++ b/src/lib/UserMinus.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/UserPlus.svelte
+++ b/src/lib/UserPlus.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/UserPlus.svelte
+++ b/src/lib/UserPlus.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Users.svelte
+++ b/src/lib/Users.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -118,7 +118,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Users.svelte
+++ b/src/lib/Users.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Variable.svelte
+++ b/src/lib/Variable.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Variable.svelte
+++ b/src/lib/Variable.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/VideoCamera.svelte
+++ b/src/lib/VideoCamera.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -94,7 +94,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/VideoCamera.svelte
+++ b/src/lib/VideoCamera.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/VideoCameraSlash.svelte
+++ b/src/lib/VideoCameraSlash.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/VideoCameraSlash.svelte
+++ b/src/lib/VideoCameraSlash.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ViewColumns.svelte
+++ b/src/lib/ViewColumns.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -96,7 +96,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ViewColumns.svelte
+++ b/src/lib/ViewColumns.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/ViewfinderCircle.svelte
+++ b/src/lib/ViewfinderCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -130,7 +130,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/ViewfinderCircle.svelte
+++ b/src/lib/ViewfinderCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Wallet.svelte
+++ b/src/lib/Wallet.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -106,7 +106,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Wallet.svelte
+++ b/src/lib/Wallet.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Wifi.svelte
+++ b/src/lib/Wifi.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Wifi.svelte
+++ b/src/lib/Wifi.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Window.svelte
+++ b/src/lib/Window.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Window.svelte
+++ b/src/lib/Window.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/Wrench.svelte
+++ b/src/lib/Wrench.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/Wrench.svelte
+++ b/src/lib/Wrench.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -95,7 +95,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/WrenchScrewdriver.svelte
+++ b/src/lib/WrenchScrewdriver.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -114,7 +114,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/WrenchScrewdriver.svelte
+++ b/src/lib/WrenchScrewdriver.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/XCircle.svelte
+++ b/src/lib/XCircle.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/XCircle.svelte
+++ b/src/lib/XCircle.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -88,7 +88,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/lib/XMark.svelte
+++ b/src/lib/XMark.svelte
@@ -18,19 +18,16 @@
 
   let ariaDescribedby = `${title?.id || ''} ${desc?.id || ''}`;
   const hasDescription = $derived(!!(title?.id || desc?.id));
-  let viewBox: string | undefined = $state(undefined);
 
-  $effect(() => {
-    if (variation === 'mini') {
-      size = size || '20';
-      viewBox = '0 0 20 20';
-    } else if (variation === 'micro') {
-      size = size || '16';
-      viewBox = '0 0 16 16';
-    } else {
-      size = size || '24';
-      viewBox = '0 0 24 24';
-    }
+  let viewBox = $derived.by(() => {
+    if (variation === 'mini') return '0 0 20 20';
+    if (variation === 'micro') return '0 0 16 16';
+    return '0 0 24 24';
+  });
+  let variationSize = $derived.by(() => {
+    if (variation === 'mini') return '20';
+    if (variation === 'micro') return '16';
+    return '24';
   });
 </script>
 
@@ -38,8 +35,8 @@
   xmlns="http://www.w3.org/2000/svg"
   {...restProps}
   {role}
-  width={size}
-  height={size}
+  width={size || variationSize}
+  height={size || variationSize}
   fill="none"
   aria-label={ariaLabel}
   aria-describedby={hasDescription ? ariaDescribedby : undefined}

--- a/src/lib/XMark.svelte
+++ b/src/lib/XMark.svelte
@@ -5,7 +5,7 @@
   const ctx: CtxType = getContext('iconCtx') ?? {};
 
   let {
-    size = ctx.size || '24',
+    size = ctx.size,
     role = ctx.role || 'img',
     color = ctx.color || 'currentColor',
     variation = ctx.variation || 'outline',
@@ -84,7 +84,7 @@
 @component
 [Go to docs](https://svelte-heros-v2.codewithshin.com/)
 ## Props
-@prop size = ctx.size || '24'
+@prop size = ctx.size
 @prop role = ctx.role || 'img'
 @prop color = ctx.color || 'currentColor'
 @prop variation = ctx.variation || 'outline'

--- a/src/routes/guide/svelte-5/props/md/props.md
+++ b/src/routes/guide/svelte-5/props/md/props.md
@@ -1,4 +1,4 @@
-- size = ctx.size || '24'
+- size = ctx.size
 - role = ctx.role || 'img'
 - color = ctx.color || 'currentColor'
 - variation = ctx.variation || "outline"


### PR DESCRIPTION
If we use an icon like this, without setting up global icon preferences
```svelte
<AcademicCap variation="mini" />
```
you would expect size to be defaulted to the variation size, like viewBox, but it is not.
```html
<svg xmlns="http://www.w3.org/2000/svg" role="img" width="24" height="24" fill="none" aria-label="academic cap" viewBox="0 0 20 20" stroke-width="1.5">
    ...
</svg>
``` 

This PR fixes the above issue, assuming this is not intended behaviour.

<details><summary>Issue Details</summary>
<br>
The issue lies in these size default assignments for the different variations

https://github.com/shinokada/svelte-heros-v2/blob/b1a805748a81954bc305e5996c0b8c908c593bd1/src/lib/AcademicCap.svelte#L24-L25

since size is never falsy as it is defaulted to '24' when declaring props, size is never asigned '20'
https://github.com/shinokada/svelte-heros-v2/blob/b1a805748a81954bc305e5996c0b8c908c593bd1/src/lib/AcademicCap.svelte#L7-L8
</details>

<details><summary>Proposal Details</summary>
<br>
This patch does a few things:

- removes the size prop default assignments to '24'
https://github.com/shinokada/svelte-heros-v2/blob/7a60c02bfe63ee7132e50461fe38ef65d33f643c/src/lib/AcademicCap.svelte#L7-L8

- instead of using an $effect, derive viewBox and variationSize from the variation prop
https://github.com/shinokada/svelte-heros-v2/blob/7a60c02bfe63ee7132e50461fe38ef65d33f643c/src/lib/AcademicCap.svelte#L22-L31

- default width and height to variationSize if size isn't set (either by the consumer component or global context)
https://github.com/shinokada/svelte-heros-v2/blob/7a60c02bfe63ee7132e50461fe38ef65d33f643c/src/lib/AcademicCap.svelte#L38-L39
</details>